### PR TITLE
[proposal] basic chat caching and fixed chat autoscrolling

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -93,6 +93,7 @@
             "simpleRetryIntervals": ["5s", "10s", "15s"]
         },
         "chat": {
+            "messageCacheLimit": 20,
             "rateLimit": "1s",
             "showConnectionMessages": false
         }

--- a/modules/chat.js
+++ b/modules/chat.js
@@ -11,6 +11,7 @@ const helpers = require('../helpers');
 module.exports = function(app, cache, chance, database, io, self) {
     const BASE_URL = config.get('server.baseURL');
     const CHAT_LOG_CHANNEL = config.has('server.slack.channels.chatLog') ? config.get('server.slack.channels.chatLog') : '#chat-log';
+    const MESSAGE_CACHE_LIMIT = config.get('app.chat.messageCacheLimit');
     const RATE_LIMIT = ms(config.get('app.chat.rateLimit'));
     const SHOW_CONNECTION_MESSAGES = config.get('app.chat.showConnectionMessages');
 
@@ -47,6 +48,16 @@ module.exports = function(app, cache, chance, database, io, self) {
     self.processOnlineListUpdate = _.debounce(co.wrap(function* processOnlineListUpdate() {
         yield updateOnlineUserList();
     }));
+
+    /**
+     * @async
+     */
+    self.displayCachedChatMessages = co.wrap(function* displayCachedChatMessages(socket) {
+        if (yield cache.existsAsync('cachedChatMessages')) {
+            const cachedChatMessages = JSON.parse(yield cache.getAsync('cachedChatMessages'));
+            socket.emit('cachedChatMessagesAvailable', cachedChatMessages);
+        }
+    }
 
     /**
      * @async
@@ -101,6 +112,16 @@ module.exports = function(app, cache, chance, database, io, self) {
         }
 
         io.sockets.emit('messageReceived', message);
+
+        // store message to cache
+        message.time = new Date();
+
+        let cachedChatMessages = yield cache.existsAsync('cachedChatMessages')) ? JSON.parse(yield cache.getAsync('cachedChatMessages')) : [];
+        while (cachedChatMessages.length >= MESSAGE_CACHE_LIMIT) {
+            cachedChatMessages.shift();
+        }
+        cachedChatMessages.push(message);
+        yield cache.setAsync('cachedChatMessages', JSON.stringify(cachedChatMessages));
     });
 
     self.on('userConnected', co.wrap(function*(userID) {
@@ -205,6 +226,8 @@ module.exports = function(app, cache, chance, database, io, self) {
         socket.removeAllListeners('sendChatMessage');
         socket.on('sendChatMessage', onUserSendChatMessage);
         socket.on('purgeUser', onUserPurgeUser);
+
+        self.displayCachedChatMessages(socket);
     });
 
     self.processOnlineListUpdate();

--- a/public/elements/pugchamp-chat/pugchamp-chat.html
+++ b/public/elements/pugchamp-chat/pugchamp-chat.html
@@ -193,12 +193,21 @@
                 this._listenToEvent('messageReceived', 'onMessageReceived');
                 this._listenToEvent('userPurged', 'onUserPurged');
                 this._listenToEvent('onlineUserListUpdated', 'onOnlineUserListUpdated');
+                this._listenToEvent('cachedChatMessagesAvailable', 'onCachedChatMessagesAvailable');
             },
             onOnlineUserListUpdated: function(list) {
                 this.set('onlineList', list);
             },
+            onCachedChatMessagesAvailable: function(messages) {
+				this.push('messages', ...messages);
+
+                this.async(function() {
+                    this.$.messages.scrollTop = this.$.messages.scrollHeight - this.$.messages.clientHeight;
+                }, 100);
+			},
             onMessageReceived: function(message) {
-                var atBottom = this.$.messages.scrollHeight - this.$.messages.scrollTop === this.$.messages.clientHeight;
+                // fixes chat not autoscrolling correctly - atBottom previously would never be true even when scrolled to the bottom
+                var atBottom = this.$.messages.scrollHeight - this.$.messages.scrollTop - this.$.messages.clientHeight < 30;
 
                 message.time = new Date();
 


### PR DESCRIPTION
When a user freshly loads the PugChamp web application, they are presented with no previously sent chat messages, meaning that active conversations lack context. This pull request proposes caching of the latest (by default, 20) chat messages (including those sent by the application, not just user-generated messages). Now, when a user logs in, the cached chat messages are emitted to the user. This feature was suggested by the user/TF2 player "fx".

This pull request also provides a fix that allows for PugChamp chat to once again autoscroll correctly if the chat was scrolled near to the bottom of the message queue.

There is undoubtedly a nicer way to implement these features, but these proposed changes have been tested to function as expected.